### PR TITLE
CRUD de Leilões refinado

### DIFF
--- a/LP2/src/main/java/com/lp2/lp2/Controller/Leilao/CreateLeilaoController.java
+++ b/LP2/src/main/java/com/lp2/lp2/Controller/Leilao/CreateLeilaoController.java
@@ -42,6 +42,14 @@ public class CreateLeilaoController {
     @FXML
     public void initialize() {
         tipoField.getItems().addAll("Online", "Carta Fechada", "Venda Direta");
+        tipoField.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
+            if ("Online".equals(newValue)) {
+                multiploLanceField.setDisable(false);
+            } else {
+                multiploLanceField.setDisable(true);
+                multiploLanceField.clear();
+            }
+        });
     }
 
     @FXML
@@ -55,7 +63,11 @@ public class CreateLeilaoController {
             leilao.setDataFim(Date.valueOf(dataFimField.getValue()));
             leilao.setValorMinimo(new BigDecimal(valorMinimoField.getText()));
             leilao.setValorMaximo(new BigDecimal(valorMaximoField.getText()));
-            leilao.setMultiploLance(new BigDecimal(multiploLanceField.getText()));
+            if ("Online".equals(tipoField.getValue())) {
+                leilao.setMultiploLance(new BigDecimal(multiploLanceField.getText()));
+            } else {
+                leilao.setMultiploLance(null); // Definir como null para outros tipos de leilão
+            }
             leilao.setInativo(false); // Definir como ativo por padrão
             leilaoDAO.addLeilao(leilao);
             mostrarMensagemSucesso("Leilão adicionado com sucesso!");

--- a/LP2/src/main/java/com/lp2/lp2/Controller/Leilao/EditLeilaoController.java
+++ b/LP2/src/main/java/com/lp2/lp2/Controller/Leilao/EditLeilaoController.java
@@ -56,6 +56,16 @@ public class EditLeilaoController {
 
     @FXML
     public void initialize() {
+        tipoField.getItems().addAll("Online", "Carta Fechada", "Venda Direta");
+        tipoField.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
+            if ("Online".equals(newValue)) {
+                multiploLanceField.setDisable(false);
+            } else {
+                multiploLanceField.setDisable(true);
+                multiploLanceField.clear();
+            }
+        });
+
         populateIdChoiceBox();
 
         idChoiceBox.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
@@ -85,10 +95,16 @@ public class EditLeilaoController {
                 descricaoField.setText(leilao.getDescricao());
                 tipoField.setValue(leilao.getTipo());
                 dataInicioField.setValue(leilao.getDataInicio().toLocalDate());
-                dataFimField.setValue(leilao.getDataFim().toLocalDate());
+                dataFimField.setValue(leilao.getDataFim() != null ? leilao.getDataFim().toLocalDate() : null);
                 valorMinimoField.setText(leilao.getValorMinimo().toString());
-                valorMaximoField.setText(leilao.getValorMaximo().toString());
-                multiploLanceField.setText(leilao.getMultiploLance().toString());
+                valorMaximoField.setText(leilao.getValorMaximo() != null ? leilao.getValorMaximo().toString() : "");
+                if ("Online".equals(leilao.getTipo())) {
+                    multiploLanceField.setDisable(false);
+                    multiploLanceField.setText(leilao.getMultiploLance() != null ? leilao.getMultiploLance().toString() : "");
+                } else {
+                    multiploLanceField.setDisable(true);
+                    multiploLanceField.clear();
+                }
             } else {
                 mostrarMensagemErro("Leilão não encontrado!");
             }
@@ -110,8 +126,11 @@ public class EditLeilaoController {
                 leilao.setDataFim(Date.valueOf(dataFimField.getValue()));
                 leilao.setValorMinimo(new BigDecimal(valorMinimoField.getText()));
                 leilao.setValorMaximo(new BigDecimal(valorMaximoField.getText()));
-                leilao.setMultiploLance(new BigDecimal(multiploLanceField.getText()));
-                // Manter o estado inativo como está
+                if ("Online".equals(tipoField.getValue())) {
+                    leilao.setMultiploLance(new BigDecimal(multiploLanceField.getText()));
+                } else {
+                    leilao.setMultiploLance(null);
+                }
                 leilaoDAO.updateLeilao(leilao);
                 mostrarMensagemSucesso("Leilão atualizado com sucesso!");
             } else {

--- a/LP2/src/main/java/com/lp2/lp2/DAO/LeilaoDAO.java
+++ b/LP2/src/main/java/com/lp2/lp2/DAO/LeilaoDAO.java
@@ -2,7 +2,7 @@ package com.lp2.lp2.DAO;
 
 import com.lp2.lp2.DAO.IDAO.ILeilaoDAO;
 import com.lp2.lp2.Model.Leilao;
-import com.lp2.lp2.Infrastucture.Connection.DBConnection ;
+import com.lp2.lp2.Infrastucture.Connection.DBConnection;
 import com.lp2.lp2.Util.CsvService;
 import com.opencsv.exceptions.CsvException;
 
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
+
 public class LeilaoDAO implements ILeilaoDAO {
     private Connection connection;
 
@@ -28,7 +29,11 @@ public class LeilaoDAO implements ILeilaoDAO {
             stmt.setDate(5, leilao.getDataFim());
             stmt.setBigDecimal(6, leilao.getValorMinimo());
             stmt.setBigDecimal(7, leilao.getValorMaximo());
-            stmt.setBigDecimal(8, leilao.getMultiploLance());
+            if (leilao.getMultiploLance() != null) {
+                stmt.setBigDecimal(8, leilao.getMultiploLance());
+            } else {
+                stmt.setNull(8, Types.DECIMAL);
+            }
             stmt.setBoolean(9, leilao.getInativo());
             stmt.executeUpdate();
 
@@ -47,14 +52,11 @@ public class LeilaoDAO implements ILeilaoDAO {
                     }
                 }
             }
-        }
-        catch (SQLException e) {
+        } catch (SQLException e) {
             System.err.println("Erro ao adicionar leilão: " + e.getMessage());
             throw e; // Re-lançando a exceção para o chamador
         }
     }
-
-
 
     @Override
     public void updateLeilao(Leilao leilao) throws SQLException {
@@ -67,7 +69,11 @@ public class LeilaoDAO implements ILeilaoDAO {
             stmt.setDate(5, leilao.getDataFim());
             stmt.setBigDecimal(6, leilao.getValorMinimo());
             stmt.setBigDecimal(7, leilao.getValorMaximo());
-            stmt.setBigDecimal(8, leilao.getMultiploLance());
+            if (leilao.getMultiploLance() != null) {
+                stmt.setBigDecimal(8, leilao.getMultiploLance());
+            } else {
+                stmt.setNull(8, Types.DECIMAL);
+            }
             stmt.setBoolean(9, leilao.getInativo());
             stmt.setInt(10, leilao.getId());
             stmt.executeUpdate();
@@ -81,7 +87,6 @@ public class LeilaoDAO implements ILeilaoDAO {
             System.err.println("Erro ao atualizar leilão no CSV: " + e.getMessage());
         }
     }
-
 
     @Override
     public void deleteLeilao(int id) throws SQLException {

--- a/LP2/src/main/java/com/lp2/lp2/Util/CsvService.java
+++ b/LP2/src/main/java/com/lp2/lp2/Util/CsvService.java
@@ -149,7 +149,7 @@ public class CsvService {
                 .build()) {
 
             if (!fileExists) {
-                writer.writeNext(LEILAO_HEADER);
+                writer.writeNext(new String[]{"ID", "Nome", "Descricao", "Tipo", "DataInicio", "DataFim", "ValorMinimo", "ValorMaximo", "MultiploLance", "Inativo"});
             }
 
             String[] data = {
@@ -158,10 +158,10 @@ public class CsvService {
                     leilao.getDescricao().trim(),
                     leilao.getTipo().trim(),
                     leilao.getDataInicio().toString().trim(),
-                    leilao.getDataFim().toString().trim(),
+                    leilao.getDataFim() != null ? leilao.getDataFim().toString().trim() : "",
                     leilao.getValorMinimo().toString().trim(),
-                    leilao.getValorMaximo().toString().trim(),
-                    leilao.getMultiploLance().toString().trim(),
+                    leilao.getValorMaximo() != null ? leilao.getValorMaximo().toString().trim() : "",
+                    leilao.getMultiploLance() != null ? leilao.getMultiploLance().toString().trim() : "",
                     String.valueOf(leilao.getInativo()).trim()
             };
             writer.writeNext(data);
@@ -188,10 +188,10 @@ public class CsvService {
                         leilao.getDescricao().trim(),
                         leilao.getTipo().trim(),
                         leilao.getDataInicio().toString().trim(),
-                        leilao.getDataFim().toString().trim(),
+                        leilao.getDataFim() != null ? leilao.getDataFim().toString().trim() : "",
                         leilao.getValorMinimo().toString().trim(),
-                        leilao.getValorMaximo().toString().trim(),
-                        leilao.getMultiploLance().toString().trim(),
+                        leilao.getValorMaximo() != null ? leilao.getValorMaximo().toString().trim() : "",
+                        leilao.getMultiploLance() != null ? leilao.getMultiploLance().toString().trim() : "",
                         String.valueOf(leilao.getInativo()).trim()
                 });
                 break;

--- a/LP2/src/main/java/com/lp2/lp2/Util/leilao.csv
+++ b/LP2/src/main/java/com/lp2/lp2/Util/leilao.csv
@@ -7,3 +7,5 @@ ID,Nome,Descricao,Tipo,DataInicio,DataFim,ValorMinimo,ValorMaximo,MultiploLance
 16,asdasd,asdsadds,Online,2025-04-03,2025-05-01,11111.00,111111.00,1.10,false
 17,asdasd,asdad,Venda Direta,2025-04-03,2025-04-24,1111,111111,1,false
 18,Casa,piscina e spa,Carta Fechada,2025-04-03,2025-04-24,11134.00,1321412.00,1.10,false
+22,sdaasd,asdsaddas,Venda Direta,2025-04-03,2025-04-17,11111,111111,,false
+23,Casa,resort,Carta Fechada,2025-04-03,2025-04-17,11111.00,111111.00,,false


### PR DESCRIPTION
Implementação da lógica para só ser possível adicionar um multiplo de lance a leilões eletrónicos/Online, sendo que ao criar um de carta fechada ou venda direta não é obrigatório colocar um multiplo de lance!